### PR TITLE
chore: fix `BasicSlide` animation

### DIFF
--- a/web/src/pages/onboarding/OnboardingContainer.tsx
+++ b/web/src/pages/onboarding/OnboardingContainer.tsx
@@ -145,7 +145,7 @@ export const OnboardingContainer: React.FC<Props> = ({
         <SetupCompleted key={progress} title={title} text={text} characterName={currentCharacter?.name ?? 'Unknown'} />
       )
     } else {
-      return <BasicSlide title={title} text={text} />
+      return <BasicSlide key={progress} title={title} text={text} />
     }
   }
 


### PR DESCRIPTION
Adds 'key' property to have `BasicSlide` remount during Lawyer demo, so it displays the animation properly