### PR TITLE
chore: fix proof request state issue

### DIFF
--- a/web/src/pages/useCase/steps/StepConnection.tsx
+++ b/web/src/pages/useCase/steps/StepConnection.tsx
@@ -11,8 +11,9 @@ import { localization } from '../../../assets/localization'
 import { QRCode } from '../../../components/QRCode'
 import { useAppDispatch } from '../../../hooks/hooks'
 import { useInterval } from '../../../hooks/useInterval'
-import { setDeepLink } from '../../../slices/connection/connectionSlice'
+import { clearConnection, setDeepLink } from '../../../slices/connection/connectionSlice'
 import { createInvitation, fetchConnectionById } from '../../../slices/connection/connectionThunks'
+import { clearProof } from '../../../slices/proof/proofSlice'
 import { nextStep } from '../../../slices/useCases/useCasesSlice'
 import { isConnected } from '../../../utils/Helpers'
 import { prependApiUrl } from '../../../utils/Url'
@@ -24,14 +25,16 @@ export interface Props {
   newConnection?: boolean
 }
 
-export const StepConnection: React.FC<Props> = ({ step, connection, newConnection }) => {
+export const StepConnection: React.FC<Props> = ({ step, connection }) => {
   const dispatch = useAppDispatch()
   const { id, state, invitationUrl } = connection
   const isCompleted = isConnected(state as string)
   const deepLink = `bcwallet://aries_connection_invitation?${invitationUrl?.split('?')[1]}`
 
   useEffect(() => {
-    if (!isCompleted || newConnection) dispatch(createInvitation(step.verifier?.name ?? 'Unknown'))
+    dispatch(clearConnection())
+    dispatch(clearProof())
+    dispatch(createInvitation(step.verifier?.name ?? 'Unknown'))
   }, [])
 
   useInterval(

--- a/web/src/pages/useCase/steps/StepProof.tsx
+++ b/web/src/pages/useCase/steps/StepProof.tsx
@@ -8,6 +8,7 @@ import { ActionCTA } from '../../../components/ActionCTA'
 import { useAppDispatch } from '../../../hooks/hooks'
 import { useInterval } from '../../../hooks/useInterval'
 import { useConnection } from '../../../slices/connection/connectionSelectors'
+import { clearProof } from '../../../slices/proof/proofSlice'
 import { createProof, deleteProofById, fetchProofById, createDeepProof } from '../../../slices/proof/proofThunks'
 import { FailedRequestModal } from '../../onboarding/components/FailedRequestModal'
 import { ProofAttributesCard } from '../components/ProofAttributesCard'
@@ -92,9 +93,12 @@ export const StepProof: React.FC<Props> = ({ proof, step, connectionId, requeste
   useEffect(() => {
     if (!proof) {
       createProofRequest()
+    } else {
+      dispatch(clearProof())
+      createProofRequest()
     }
     return () => {
-      dispatch({ type: 'clearProof' })
+      dispatch(clearProof())
     }
   }, [])
 


### PR DESCRIPTION
Add additional connection / proof resets between slides. 

On the Use Case pages, when going back from the Proof request status page, the proof connection wasn't being cleared. This caused a bug where if the app needed to send a new proof request, it was stuck listening for the old one.