### PR TITLE
fix: pass all parameters for get requests

### DIFF
--- a/api/src/utils/traction.ts
+++ b/api/src/utils/traction.ts
@@ -54,6 +54,7 @@ export const sendTractionRequest = async (
 
   console.log(`api: traction request: ${method} ${url}`)
   const response = await axios.request({
+    ...config,
     method,
     url,
     data,


### PR DESCRIPTION
c3a7248fd46a443646cae61419504cbd8de0494b accidentally changed the behavior of `tractionRequest.get()`, discarding url parameters.

Root cause of #41 (and likely other bugs).